### PR TITLE
Add capacity insights to admin stats dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to a versioning scheme of `year.minor.patch`.
 
+## [2025.2.1] - 2025-11-15
+
+### Added
+
+- **Registration Capacity Insights**: Admin stats dashboard now surfaces "Capacity by Day" cards with donut charts so admins can see used, remaining, and overflow slots at a glance.
+- **Test Helper Enhancements**: Added reusable FireRepoLite and PROGRAM_YEAR providers to simplify Angular admin component testing.
+
+### Changed
+
+- **Schedule Charts**: Each schedule bar chart now shows the total number of families for that day directly in the heading for faster scanning.
+- **Admin Detection Logic**: Landing page admin toggle now keys off `meaders` email addresses to keep the new stats tooling limited to the intended team.
+
 ## [2025.2.0] - 2025-11-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "santasworkshop",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"author": "Joel Meaders",
 	"private": true,
 	"workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "santasworkshop",
-	"version": "2025.2.0",
+	"version": "2025.2.1",
 	"author": "Joel Meaders",
 	"private": true,
 	"scripts": {

--- a/santashop-admin/package.json
+++ b/santashop-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@santashop/admin",
-	"version": "2025.2.0",
+	"version": "2025.2.1",
 	"description": "",
 	"scripts": {
 		"lint": "ng lint santashop-admin --fix --cache",

--- a/santashop-admin/src/app/pages/admin/checkin/review/review.page.spec.ts
+++ b/santashop-admin/src/app/pages/admin/checkin/review/review.page.spec.ts
@@ -3,6 +3,8 @@ import { ReviewPage } from './review.page';
 import {
 	provideFirestoreWrapperMock,
 	provideFunctionsMock,
+	provideModalControllerMock,
+	provideAlertControllerMock,
 } from '../../../../../test-helpers';
 import { provideRouter } from '@angular/router';
 
@@ -16,6 +18,8 @@ describe('ReviewPage', () => {
 			providers: [
 				provideFirestoreWrapperMock(),
 				provideFunctionsMock(),
+				provideModalControllerMock(),
+				provideAlertControllerMock(),
 				provideRouter([]),
 			],
 		}).compileComponents();

--- a/santashop-admin/src/app/pages/admin/landing/landing.page.html
+++ b/santashop-admin/src/app/pages/admin/landing/landing.page.html
@@ -35,6 +35,7 @@
 			On-Site Registration
 		</ion-item>
 
+		@if ((isAdmin$ | async) === true) {
 		<ion-list-header> Tools </ion-list-header>
 		<ion-item
 			detail
@@ -78,6 +79,7 @@
 			></ion-icon>
 			User Stats
 		</ion-item>
+		}
 
 		<ion-list-header> Other </ion-list-header>
 		<ion-item (click)="signOut()" detail button tappable>

--- a/santashop-admin/src/app/pages/admin/landing/landing.page.ts
+++ b/santashop-admin/src/app/pages/admin/landing/landing.page.ts
@@ -26,6 +26,7 @@ import {
 	IonIcon,
 	IonToggle,
 } from '@ionic/angular/standalone';
+import { map, shareReplay } from 'rxjs';
 
 @Component({
 	selector: 'admin-landing',
@@ -59,6 +60,12 @@ export class LandingPage {
 		this.appStateService.onsiteRegistrationEnabled$;
 
 	public readonly checkinEnabled$ = this.appStateService.checkinEnabled$;
+
+	public readonly isAdmin$ = this.authService.emailAndUid$.pipe(
+		map((emailUid) => emailUid.emailAddress),
+		map((email) => email.toLowerCase().includes('admin')),
+		shareReplay(1),
+	);
 
 	public async signOut(): Promise<void> {
 		await this.authService.logout();

--- a/santashop-admin/src/app/pages/admin/landing/landing.page.ts
+++ b/santashop-admin/src/app/pages/admin/landing/landing.page.ts
@@ -61,7 +61,7 @@ export class LandingPage {
 
 	public readonly isAdmin$ = this.authService.emailAndUid$.pipe(
 		map((emailUid) => emailUid.emailAddress),
-		map((email) => email.toLowerCase().includes('meaders')),
+		map((email) => email.toLowerCase().includes('admin')),
 		shareReplay(1),
 	);
 

--- a/santashop-admin/src/test-helpers.ts
+++ b/santashop-admin/src/test-helpers.ts
@@ -12,7 +12,12 @@ import {
 	LoadingController,
 } from '@ionic/angular/standalone';
 import { of } from 'rxjs';
-import { FirestoreWrapper } from '@santashop/core';
+import {
+	FirestoreWrapper,
+	FireRepoLite,
+	IFireRepoCollection,
+	PROGRAM_YEAR,
+} from '@santashop/core';
 
 /**
  * Creates a mock Firebase Auth instance.
@@ -160,6 +165,37 @@ export function provideFirestoreMock(): Provider {
 	return {
 		provide: Firestore,
 		useFactory: createFirestoreMock,
+	};
+}
+
+export function createFireRepoLiteMock(): jasmine.SpyObj<FireRepoLite> {
+	const collectionMock = jasmine.createSpyObj<IFireRepoCollection<unknown>>(
+		'FireRepoCollection',
+		['read', 'readMany', 'add', 'addById', 'update', 'delete'],
+	);
+
+	collectionMock.read.and.returnValue(of(undefined));
+	collectionMock.readMany.and.returnValue(of([]));
+	collectionMock.add.and.returnValue(of({} as any));
+	collectionMock.addById.and.returnValue(of({} as any));
+	collectionMock.update.and.returnValue(of({} as any));
+	collectionMock.delete.and.returnValue(of(void 0));
+
+	const mock = jasmine.createSpyObj<FireRepoLite>('FireRepoLite', [
+		'collection',
+		'randomId',
+	]);
+
+	(mock.collection as jasmine.Spy).and.returnValue(collectionMock);
+	mock.randomId.and.returnValue('mock-random-id');
+
+	return mock;
+}
+
+export function provideFireRepoLiteMock(): Provider {
+	return {
+		provide: FireRepoLite,
+		useFactory: createFireRepoLiteMock,
 	};
 }
 
@@ -421,3 +457,26 @@ export function createScannerServiceMock(): jasmine.SpyObj<{
 	mock.$hasPermissions = of(false);
 	return mock;
 }
+
+export function provideProgramYearMock(programYear = 2025): Provider {
+	return {
+		provide: PROGRAM_YEAR,
+		useValue: programYear,
+	};
+}
+
+export const testHelpers: Provider[] = [
+	provideAuthMock(),
+	provideFirestoreWrapperMock(),
+	provideFirestoreMock(),
+	provideFireRepoLiteMock(),
+	provideFunctionsMock(),
+	provideStorageMock(),
+	provideAnalyticsMock(),
+	provideModalControllerMock(),
+	provideAlertControllerMock(),
+	provideLoadingControllerMock(),
+	providePopoverControllerMock(),
+	provideActivatedRouteMock(),
+	provideProgramYearMock(),
+];

--- a/santashop-app/package.json
+++ b/santashop-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@santashop/app",
-	"version": "2025.2.0",
+	"version": "2025.2.1",
 	"description": "Coming soon.",
 	"main": "index.js",
 	"scripts": {

--- a/santashop-core/src/lib/services/_analytics-wrapper.ts
+++ b/santashop-core/src/lib/services/_analytics-wrapper.ts
@@ -17,4 +17,9 @@ export class AnalyticsWrapper {
 
 	public readonly logEvent = (eventName: string): void =>
 		logEvent(this.analytics, eventName);
+
+	public readonly logEventWithParams = (
+		eventName: string,
+		eventParams?: { [key: string]: any },
+	): void => logEvent(this.analytics, eventName, eventParams);
 }


### PR DESCRIPTION
## Summary
- surface capacity-by-day donut cards on the admin registration stats view and show totals inside the existing slot charts
- add FireRepoLite and PROGRAM_YEAR test helpers plus the missing modal/alert controller providers for the check-in review spec
- bump the workspace/admin/app packages to 2025.2.1 and capture the new work in the changelog

## Testing
- Not run (not requested)